### PR TITLE
Retire React Bootstrap

### DIFF
--- a/practices/core-technologies.md
+++ b/practices/core-technologies.md
@@ -7,10 +7,17 @@ We current have experience and expertise in:
 
 * Python
 * Javascript
+* Typescript
 * HTML/CSS
 * AWS
 
 ## Language specific tools and frameworks
+
+Things marked **Do use** feel free to use where you want.
+
+Things in **Retire** means that we still have code that uses this and it is okay to continue to use it where it is already in use but we should not create any more code using it. We should take the opportunities to remove it from our codebase where they arise.
+
+Things marked as **Don't use** means that we have either retired this successfully or we have tried it and it hasn't worked out and should only be re-trialled if we have had a proper review of what did not work before and why things might now be different.
 
 ### Python
 
@@ -20,11 +27,9 @@ We current have experience and expertise in:
 
 #### Retire
 
-Currently in use but don't use more of it
-
 * Turbogears
 
-### Javascript
+### Javascript/Typescript
 
 #### Do use
 
@@ -38,6 +43,8 @@ Currently in use but don't use more of it
 * Flow (use Typescript instead)
 * LESS
 * jQuery
+* React class-based components (use Stateless components instead)
+* React Bootstrap
 
 #### Don't use
 


### PR DESCRIPTION
React Bootstrap is currently migrating to be based on Bootstrap 4 which is a change that we're not currently ready to make. Although I believe that security updates might be issued for the library all the
documentation is being switched over to newer versions which makes it difficult to understand how to structure the old-style components.

If you think some components of this library are particularly useful we should start thinking about having some standard POP components instead that implement our hybrid of Bootstrap 3 plus our Styleguide.