### PR TITLE
Python: Use of init files

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -6,7 +6,7 @@ layout: default
 
 	<h1>POP development team</h1>
 	
-	<p>A record of the practice and conventions that the POP team have built up over time.</p>
+	<p>A guide to developing software at POP and a record of the decisions we have made as a team as to how we wish to create and deliver software.</p>
 
 	<ul>
 		<li><a href="policies">Policies</a></li>

--- a/about.md
+++ b/about.md
@@ -5,4 +5,6 @@ title: About
 
 This is a collection of high-level advice and guidance that covers all of the POP projects and deliverables.
 
-It is written primarily for the development team and represents the common practices the team should try to adhere too.
+It is written primarily for the development team and represents the common practices the team should try to adhere too. Changes and proposals should be made via a PR to the relevant repo. See the CONTRIBUTING document for more information.
+
+It is a public document to help share our experience and as a thank you to other teams that have shared their ideas with us.

--- a/practices/python/frameworks.md
+++ b/practices/python/frameworks.md
@@ -1,0 +1,15 @@
+---
+layout: page
+title: Python frameworks
+---
+
+Refer to the general [guidance](../roadmap-guidance) as to what the categories that follow mean.
+
+
+## Do use
+
+* Flask
+
+## Retire
+
+* Turbogears

--- a/practices/python/index.md
+++ b/practices/python/index.md
@@ -1,0 +1,9 @@
+---
+layout: page
+title: Python programming advice
+---
+
+
+
+* [Advice on using init files](init-files)
+* [Frameworks and library advice](frameworks)

--- a/practices/python/init-files.md
+++ b/practices/python/init-files.md
@@ -1,0 +1,20 @@
+---
+layout: page
+title: Using init files effectively
+---
+
+
+Init files should only be used to:
+
+* hide the internal structure of a package
+* declare constant values that do not have high computation value
+
+Despite the name pre-emptive or anticipatory initialisation should not be done in init files but instead when the relevant functionality is first used.
+
+This avoids unexpected resource usage when the package is loaded in say a testing context or in other short-lived execution contexts such as Lambda invocations.
+
+It also avoids complexity dependency interactions such as for example initialising the ORM system.
+
+We have also had problems with circular dependencies on initialisation as a result of side-effects in initialisation code.
+
+If you want to try and have a more predicatable initilisation point then consider an explicit initialisation function that can be invoked at a specified point in the code (for example, in Turbogear hooks). This will allow you to do intensive or expensive activity before say web requests were being served but without happening as soon as the code is imported.

--- a/practices/python/init-files.md
+++ b/practices/python/init-files.md
@@ -17,4 +17,4 @@ It also avoids complexity dependency interactions such as for example initialisi
 
 We have also had problems with circular dependencies on initialisation as a result of side-effects in initialisation code.
 
-If you want to try and have a more predicatable initilisation point then consider an explicit initialisation function that can be invoked at a specified point in the code (for example, in Turbogear hooks). This will allow you to do intensive or expensive activity before say web requests were being served but without happening as soon as the code is imported.
+If you want to try and have a more predictable initialisation point then consider an explicit initialisation function that can be invoked at a specified point in the code (for example, in Turbogear hooks). This will allow you to do intensive or expensive activity before say web requests were being served but without happening as soon as the code is imported.

--- a/practices/roadmap-guidance.md
+++ b/practices/roadmap-guidance.md
@@ -1,41 +1,12 @@
 ---
+title: Technical Roadmap Guidance
 layout: page
-title: Core Technologies
 ---
 
-We current have experience and expertise in:
-
-* [Python](python)
-* Javascript
-* Typescript
-* HTML/CSS
-* AWS
-
-## Language specific tools and frameworks
+Rather than having a formal technical roadmap we instead have guidance on particular technologies and the category they fall into.
 
 Things marked **Do use** feel free to use where you want.
 
 Things in **Retire** means that we still have code that uses this and it is okay to continue to use it where it is already in use but we should not create any more code using it. We should take the opportunities to remove it from our codebase where they arise.
 
 Things marked as **Don't use** means that we have either retired this successfully or we have tried it and it hasn't worked out and should only be re-trialled if we have had a proper review of what did not work before and why things might now be different.
-
-### Javascript/Typescript
-
-#### Do use
-
-* Webpack
-* React
-* CSS Modules
-
-#### Retire
-
-* Redux (use React Hooks instead)
-* Flow (use Typescript instead)
-* LESS
-* jQuery
-* React class-based components (use Stateless components instead)
-* React Bootstrap
-
-#### Don't use
-
-* Inline styling in React Components


### PR DESCRIPTION
This includes a little tidying up to create a Python subsection but the main area of advice is on avoiding side-effects and heavy initialisation in init files.

If we start to follow this it should make our code easier to deploy in different environments and avoid some of the nasty tangles we have in some of our package initialisation today.