### PR TITLE
Code review: new testing policy

### DIFF
--- a/practices/code-reviews.md
+++ b/practices/code-reviews.md
@@ -36,7 +36,7 @@ A PR must pass the full test suite of the code base to be approved and merged.
 
 There may be some exceptions to this rule (for example changing microcopy in the UI) but where this is the case the PR's submitter *must* explain why the tests are not required for the change.
 
-In the case of an emergency deploy, the full test coverage should follow as soon as possible. If not done immediately after, an issue should be created in Github and assigned to someone to create the missing test coverage. This should be prioritised over all other non-emergency work.
+In the case of an emergency deploy, the full test coverage should follow as soon as possible. If not done immediately after the initial release, an Issue should be created in Github and assigned to someone to create the missing test coverage. This should be prioritised over all other non-emergency work.
 
 ## Large pull requests
 

--- a/practices/code-reviews.md
+++ b/practices/code-reviews.md
@@ -34,9 +34,10 @@ A PR should have appropriate unit or functional tests that demonstrate both the 
 
 A PR must pass the full test suite of the code base to be approved and merged.
 
-There may be some exceptions to this rule (for example changing microcopy in the UI) but where this is the not the case the PR's submitter *must* explain why the tests are not required for the change.
+There may be some exceptions to this rule (for example changing microcopy in the UI) but where this is the case the PR's submitter *must* explain why the tests are not required for the change.
 
-In the case of an emergency deploy, the full test coverage should follow as soon as possible. If not done immediately after, an issue should be created in github for the missing test coverage.
+In the case of an emergency deploy, the full test coverage should follow as soon as possible. If not done immediately after, an issue should be created in Github and assigned to someone to create the missing test coverage. This should be prioritised over all other non-emergency work.
+
 ## Large pull requests
 
 If a change consists of more than 20 file changes then the PR should be considered as unreviewable. Sometimes changes on this scale are inevitable but always try to find ways to create smaller sequences of changes.


### PR DESCRIPTION
This is the first draft revision of the new review policy on tests accompanying the code.

This follows on from a verbal discussion in one of our retrospectives but this PR should hold any further discussion.