### PR TITLE
Atom & Sublime setup pages

### DIFF
--- a/practices/text-editors/index.md
+++ b/practices/text-editors/index.md
@@ -5,4 +5,6 @@ title: Text Editor Setup
 
 
 
+* [Setting Up Atom](setting-up-atom.md)
+* [Setting Up Sublime](setting-up-sublime.md)
 * [Setting Up VSCode](setting-up-vscode.md)

--- a/practices/text-editors/setting-up-atom.md
+++ b/practices/text-editors/setting-up-atom.md
@@ -1,0 +1,25 @@
+---
+layout: page
+title: Setting Up Atom
+---
+
+### Mandatory Extensions:
+
+* [Python-black](https://atom.io/packages/python-black)
+* [Atom-typescript](https://atom.io/packages/atom-typescript)
+* [Autocomplete-python](https://atom.io/packages/autocomplete-python)
+* [Ide-python](https://atom.io/packages/ide-python)
+* [Ide-typescript](https://atom.io/packages/ide-typescript)
+* [Linter-eslint](https://atom.io/packages/linter-eslint)
+* [Linter-flake8](https://atom.io/packages/linter-flake8)
+* [Linter-tslint](https://atom.io/packages/linter-tslint)
+* [Prettier-atom](https://atom.io/packages/prettier-atom)
+* [React](https://atom.io/packages/react)
+
+### Optional Extensions:
+
+* [Git-blame](https://atom.io/packages/git-blame)
+* [Git-time-machine](https://atom.io/packages/git-time-machine)
+* [Minimap](https://atom.io/packages/minimap)
+* [Goto-definition](https://atom.io/packages/goto-definition)
+* [Highlight-selected](https://atom.io/packages/highlight-selected)

--- a/practices/text-editors/setting-up-atom.md
+++ b/practices/text-editors/setting-up-atom.md
@@ -3,8 +3,6 @@ layout: page
 title: Setting Up Atom
 ---
 
-[*Back to Text Editors*](index.md)
-
 ### Mandatory Extensions:
 
 * [Python-black](https://atom.io/packages/python-black)

--- a/practices/text-editors/setting-up-atom.md
+++ b/practices/text-editors/setting-up-atom.md
@@ -3,6 +3,8 @@ layout: page
 title: Setting Up Atom
 ---
 
+[*Back to Text Editors*](index.md)
+
 ### Mandatory Extensions:
 
 * [Python-black](https://atom.io/packages/python-black)

--- a/practices/text-editors/setting-up-sublime.md
+++ b/practices/text-editors/setting-up-sublime.md
@@ -1,0 +1,18 @@
+---
+layout: page
+title: Setting Up Sublime
+---
+
+### Mandatory Extensions:
+
+* [Sublack](https://github.com/jgirardet/sublack)
+* [JsPrettier](https://github.com/jonlabelle/SublimeJsPrettier)
+
+### Optional Extensions:
+
+* [Kite](https://www.kite.com/integrations/sublime-text/)
+* [Less](https://github.com/danro/LESS-sublime)
+* [JSX](https://github.com/allanhortle/JSX)
+* [Typescript](https://github.com/microsoft/TypeScript-Sublime-Plugin)
+* [Terraform](https://github.com/alexlouden/Terraform.tmLanguage)
+

--- a/practices/text-editors/setting-up-sublime.md
+++ b/practices/text-editors/setting-up-sublime.md
@@ -3,8 +3,6 @@ layout: page
 title: Setting Up Sublime
 ---
 
-[*Back to Text Editors*](index.md)
-
 ### Mandatory Extensions:
 
 * [Sublack](https://github.com/jgirardet/sublack)

--- a/practices/text-editors/setting-up-sublime.md
+++ b/practices/text-editors/setting-up-sublime.md
@@ -3,6 +3,8 @@ layout: page
 title: Setting Up Sublime
 ---
 
+[*Back to Text Editors*](index.md)
+
 ### Mandatory Extensions:
 
 * [Sublack](https://github.com/jgirardet/sublack)

--- a/practices/text-editors/setting-up-sublime.md
+++ b/practices/text-editors/setting-up-sublime.md
@@ -15,4 +15,3 @@ title: Setting Up Sublime
 * [JSX](https://github.com/allanhortle/JSX)
 * [Typescript](https://github.com/microsoft/TypeScript-Sublime-Plugin)
 * [Terraform](https://github.com/alexlouden/Terraform.tmLanguage)
-

--- a/practices/text-editors/setting-up-vscode.md
+++ b/practices/text-editors/setting-up-vscode.md
@@ -3,8 +3,6 @@ layout: page
 title: Setting Up Visual Studio Code
 ---
 
-[*Back to Text Editors*](index.md)
-
 ### Mandatory Extensions:
 
 * [Black](https://github.com/psf/black)

--- a/practices/text-editors/setting-up-vscode.md
+++ b/practices/text-editors/setting-up-vscode.md
@@ -3,6 +3,8 @@ layout: page
 title: Setting Up Visual Studio Code
 ---
 
+[*Back to Text Editors*](index.md)
+
 ### Mandatory Extensions:
 
 * [Black](https://github.com/psf/black)


### PR DESCRIPTION
Added pages for Atom and Sublime Setup within the Text Editor section of Practices.
Each page contains a list of mandatory and optional extensions with their respective links.